### PR TITLE
Fix hardcoded db in migrations

### DIFF
--- a/backend/fix_permissions.py
+++ b/backend/fix_permissions.py
@@ -5,6 +5,8 @@ import psycopg2
 import logging
 import time
 
+from psycopg2.extensions import AsIs
+
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -57,7 +59,7 @@ def fix_permissions():
         
         # Execute the script
         logger.info("Executing fix permissions SQL script...")
-        cursor.execute(sql_script)
+        cursor.execute(sql_script, {"db_name": AsIs(conn.info.dbname)})
         
         logger.info("Permissions fixed successfully")
         

--- a/backend/fix_permissions.sql
+++ b/backend/fix_permissions.sql
@@ -7,7 +7,7 @@ ALTER ROLE warranty_user WITH SUPERUSER;
 ALTER ROLE warranty_user WITH CREATEROLE;
 
 -- Ensure all database objects are accessible
-GRANT ALL PRIVILEGES ON DATABASE warranty_db TO warranty_user;
+GRANT ALL PRIVILEGES ON DATABASE %(db_name)s TO warranty_user;
 GRANT ALL PRIVILEGES ON SCHEMA public TO warranty_user;
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO warranty_user;
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO warranty_user;
@@ -45,7 +45,7 @@ BEGIN
         BEGIN
             EXECUTE 'ALTER FUNCTION public.' || quote_ident(rec.proname) || '(' || pg_get_function_arguments(rec.oid) || ') OWNER TO warranty_user';
         EXCEPTION WHEN OTHERS THEN
-            RAISE NOTICE 'Error changing ownership of function %: %', rec.proname, SQLERRM;
+            RAISE NOTICE 'Error changing ownership of function %%: %%', rec.proname, SQLERRM;
         END;
     END LOOP;
 END $$; 

--- a/backend/migrations/010_configure_admin_roles.sql
+++ b/backend/migrations/010_configure_admin_roles.sql
@@ -11,7 +11,7 @@ END
 $$;
 
 -- Grant privileges to the admin role
-GRANT ALL PRIVILEGES ON DATABASE warranty_db TO warracker_admin;
+GRANT ALL PRIVILEGES ON DATABASE %(db_name)s TO warracker_admin;
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO warracker_admin;
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO warracker_admin;
 GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public TO warracker_admin;

--- a/backend/migrations/011_ensure_admin_permissions.sql
+++ b/backend/migrations/011_ensure_admin_permissions.sql
@@ -4,7 +4,7 @@
 ALTER ROLE warranty_user WITH SUPERUSER;
 
 -- Ensure all tables are accessible
-GRANT ALL PRIVILEGES ON DATABASE warranty_db TO warranty_user;
+GRANT ALL PRIVILEGES ON DATABASE %(db_name)s TO warranty_user;
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO warranty_user;
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO warranty_user;
 GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public TO warranty_user;
@@ -39,5 +39,5 @@ BEGIN
     );
 EXCEPTION WHEN OTHERS THEN
     -- Log error but continue
-    RAISE NOTICE 'Error setting ownership: %', SQLERRM;
+    RAISE NOTICE 'Error setting ownership: %%', SQLERRM;
 END $$; 

--- a/backend/migrations/apply_migrations.py
+++ b/backend/migrations/apply_migrations.py
@@ -7,6 +7,8 @@ import time
 import sys
 import importlib.util
 
+from psycopg2.extensions import AsIs
+
 # Set up logging
 logging.basicConfig(
     level=logging.INFO,
@@ -111,7 +113,7 @@ def apply_migrations():
                     with open(migration_file, 'r') as f:
                         sql = f.read()
                     
-                    cur.execute(sql)
+                    cur.execute(sql, {"db_name": AsIs(conn.info.dbname)})
                 elif migration_file.endswith('.py'):
                     # Apply Python migration
                     migration_module = load_python_migration(migration_file)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - ./backend/migrations:/app/migrations
     environment:
       - DB_HOST=warrackerdb
-      - DB_NAME=warranty_db
+      - DB_NAME=warranty_test
       - DB_USER=warranty_user
       - DB_PASSWORD=${DB_PASSWORD:-warranty_password}
       - DB_ADMIN_USER=warracker_admin
@@ -38,12 +38,12 @@ services:
       - postgres_data:/var/lib/postgresql/data
       - ./backend/init.sql:/docker-entrypoint-initdb.d/init.sql
     environment:
-      - POSTGRES_DB=warranty_db
+      - POSTGRES_DB=warranty_test
       - POSTGRES_USER=warranty_user
       - POSTGRES_PASSWORD=${DB_PASSWORD:-warranty_password}
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U warranty_user -d warranty_db"]
+      test: ["CMD-SHELL", "pg_isready -U warranty_user -d warranty_test"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Hello, I noticed that since I was using a different `DB_NAME` the migration was failing ending with an incomplete db.

This MR remove the hardcoded db name from the migration files so it can fully support using a different db name.