### PR TITLE
Remove hardcoded db_user db_admin_user and db_admin_password

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,8 +65,8 @@ while [ $attempt -lt $max_attempts ]; do\n\
     exit 1\n\
   fi\n\
   # Use timeout to prevent indefinite hanging if DB is not ready\n\
-  if PGPASSWORD=$DB_PASSWORD psql -w -h $DB_HOST -U $DB_USER -d $DB_NAME -c "ALTER ROLE warranty_user WITH SUPERUSER;" 2>/dev/null; then\n\
-    echo "Successfully granted superuser privileges to warranty_user"\n\
+  if PGPASSWORD=$DB_PASSWORD psql -w -h $DB_HOST -U $DB_USER -d $DB_NAME -c "ALTER ROLE $DB_USER WITH SUPERUSER;" 2>/dev/null; then\n\
+    echo "Successfully granted superuser privileges to $DB_USER"\n\
     break\n\
   else\n\
     echo "Failed to grant privileges (attempt $((attempt+1))), retrying in 5 seconds..."\n\

--- a/backend/app.py
+++ b/backend/app.py
@@ -2126,7 +2126,7 @@ def update_user(user_id):
         
         data = request.get_json()
         
-        # Use regular connection since warranty_user now has superuser privileges
+        # Use regular connection since db_user now has superuser privileges
         conn = get_db_connection()
         with conn.cursor() as cur:
             # Check if user exists
@@ -2181,7 +2181,7 @@ def delete_user(user_id):
             logger.warning(f"User {request.user['username']} attempted to delete their own account")
             return jsonify({"message": "Cannot delete your own account through admin API"}), 403
         
-        # Use regular connection since warranty_user now has superuser privileges
+        # Use regular connection since db_user now has superuser privileges
         conn = get_db_connection()
         with conn.cursor() as cur:
             # Check if user exists

--- a/backend/fix_permissions.py
+++ b/backend/fix_permissions.py
@@ -59,7 +59,13 @@ def fix_permissions():
         
         # Execute the script
         logger.info("Executing fix permissions SQL script...")
-        cursor.execute(sql_script, {"db_name": AsIs(conn.info.dbname)})
+        cursor.execute(
+            sql_script,
+            {
+                "db_name": AsIs(DB_NAME),
+                "db_user": AsIs(DB_USER),
+            }
+        )
         
         logger.info("Permissions fixed successfully")
         

--- a/backend/migrations/010_configure_admin_roles.sql
+++ b/backend/migrations/010_configure_admin_roles.sql
@@ -3,27 +3,27 @@
 -- Create a new database role for admin operations
 DO $$ 
 BEGIN
-    -- Check if the admin_role exists, if not create it
-    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'warracker_admin') THEN
-        CREATE ROLE warracker_admin WITH LOGIN PASSWORD 'change_this_password_in_production';
+    -- Check if the db_admin_user exists, if not create it
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '%(db_admin_user)s') THEN
+        CREATE ROLE %(db_admin_user)s WITH LOGIN PASSWORD '%(db_admin_password)s';
     END IF;
 END
 $$;
 
 -- Grant privileges to the admin role
-GRANT ALL PRIVILEGES ON DATABASE %(db_name)s TO warracker_admin;
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO warracker_admin;
-GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO warracker_admin;
-GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public TO warracker_admin;
+GRANT ALL PRIVILEGES ON DATABASE %(db_name)s TO %(db_admin_user)s;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO %(db_admin_user)s;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO %(db_admin_user)s;
+GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public TO %(db_admin_user)s;
 
 -- Grant specific role management permissions
-ALTER ROLE warracker_admin WITH CREATEROLE;
+ALTER ROLE %(db_admin_user)s WITH CREATEROLE;
 
--- Ensure the warranty_user can still access all application tables
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO warranty_user;
-GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO warranty_user;
-GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public TO warranty_user;
+-- Ensure the db_user can still access all application tables
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO %(db_user)s;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO %(db_user)s;
+GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public TO %(db_user)s;
 
--- Make warracker_admin the owner of all existing users
+-- Make db_admin_user the owner of all existing users
 -- Note: This would require superuser privileges to execute
--- ALTER ROLE warranty_user OWNER TO warracker_admin; 
+-- ALTER ROLE %(db_user)s OWNER TO %(db_admin_user)s; 

--- a/backend/migrations/011_ensure_admin_permissions.sql
+++ b/backend/migrations/011_ensure_admin_permissions.sql
@@ -1,38 +1,38 @@
 -- Migration: Ensure Admin Permissions
 
--- Grant superuser privileges to warranty_user
-ALTER ROLE warranty_user WITH SUPERUSER;
+-- Grant superuser privileges to db_user
+ALTER ROLE %(db_user)s WITH SUPERUSER;
 
 -- Ensure all tables are accessible
-GRANT ALL PRIVILEGES ON DATABASE %(db_name)s TO warranty_user;
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO warranty_user;
-GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO warranty_user;
-GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public TO warranty_user;
+GRANT ALL PRIVILEGES ON DATABASE %(db_name)s TO %(db_user)s;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO %(db_user)s;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO %(db_user)s;
+GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public TO %(db_user)s;
 
 -- Ensure role can create and manage roles
-ALTER ROLE warranty_user WITH CREATEROLE;
+ALTER ROLE %(db_user)s WITH CREATEROLE;
 
--- Create a function to ensure the warranty_user is the owner of all database objects
+-- Create a function to ensure the db_user is the owner of all database objects
 DO $$
 BEGIN
-    -- Make warranty_user the owner of all tables
+    -- Make db_user the owner of all tables
     EXECUTE (
-        SELECT 'ALTER TABLE ' || quote_ident(tablename) || ' OWNER TO warranty_user;'
+        SELECT 'ALTER TABLE ' || quote_ident(tablename) || ' OWNER TO %(db_user)s;'
         FROM pg_tables
         WHERE schemaname = 'public'
     );
     
-    -- Make warranty_user the owner of all sequences
+    -- Make db_user the owner of all sequences
     EXECUTE (
-        SELECT 'ALTER SEQUENCE ' || quote_ident(sequencename) || ' OWNER TO warranty_user;'
+        SELECT 'ALTER SEQUENCE ' || quote_ident(sequencename) || ' OWNER TO %(db_user)s;'
         FROM pg_sequences
         WHERE schemaname = 'public'
     );
     
-    -- Make warranty_user the owner of all functions
+    -- Make db_user the owner of all functions
     EXECUTE (
         SELECT 'ALTER FUNCTION ' || quote_ident(proname) || '(' || 
-               pg_get_function_arguments(p.oid) || ') OWNER TO warranty_user;'
+               pg_get_function_arguments(p.oid) || ') OWNER TO %(db_user)s;'
         FROM pg_proc p
         JOIN pg_namespace n ON p.pronamespace = n.oid
         WHERE n.nspname = 'public'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - POSTGRES_PASSWORD=${DB_PASSWORD:-warranty_password}
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U warranty_user -d warranty_test"]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
With this change all other hardcoded credentials are replaced by the ones set in environment variables of the docker compose file, including the DB_ADMIN_PASSWORD that will not require a manual change after the deployment of the service anymore.