### PR TITLE
Incorrect checksum parameter causing false duplicate detection in Paperless-ngx

### DIFF
--- a/backend/paperless_handler.py
+++ b/backend/paperless_handler.py
@@ -92,7 +92,7 @@ class PaperlessHandler:
 
                 params={
 
-                    'checksum': checksum,
+                    'checksum__iexact': checksum,
 
                     'ordering': '-created',
 


### PR DESCRIPTION
This PR fixes a critical bug where an invalid API parameter (`checksum` instead of `checksum__iexact`) caused Paperless-ngx to incorrectly identify all new document uploads as duplicates, linking them to existing documents rather than uploading them.