### PR TITLE
Add label source to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Start with Python base image
 FROM python:3.12-slim-bookworm
-
+LABEL org.opencontainers.image.source="https://github.com/sassanix/Warracker"
 # Install build tools, dev headers, nginx, etc.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This pull request makes a minor update to the `Dockerfile` by adding a label that references the GitHub repository source for the image. This helps improve traceability and documentation of the container image. Useful for bot like dependabot or Renovate to fetch the changelog.
source : https://docs.renovatebot.com/key-concepts/changelogs/
https://docs.renovatebot.com/modules/datasource/docker/
