### PR TITLE
Security: Hardcoded default database credentials in production config

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -38,10 +38,10 @@ class Config:
     # Database Configuration
     DB_HOST = os.environ.get('DB_HOST', 'warrackerdb')
     DB_NAME = os.environ.get('DB_NAME', 'warranty_db')
-    DB_USER = os.environ.get('DB_USER', 'warranty_user')
-    DB_PASSWORD = os.environ.get('DB_PASSWORD', 'warranty_password')
-    DB_ADMIN_USER = os.environ.get('DB_ADMIN_USER', 'warracker_admin')
-    DB_ADMIN_PASSWORD = os.environ.get('DB_ADMIN_PASSWORD', 'change_this_password_in_production')
+    DB_USER = os.environ.get('DB_USER')
+    DB_PASSWORD = os.environ.get('DB_PASSWORD')
+    DB_ADMIN_USER = os.environ.get('DB_ADMIN_USER')
+    DB_ADMIN_PASSWORD = os.environ.get('DB_ADMIN_PASSWORD')
     
     # File Upload Configuration
     UPLOAD_FOLDER = os.environ.get('UPLOAD_FOLDER', '/data/uploads')
@@ -118,6 +118,13 @@ class ProductionConfig(Config):
     
     @staticmethod
     def init_app(app):
+        missing_db_vars = [
+            var for var in ('DB_USER', 'DB_PASSWORD', 'DB_ADMIN_USER', 'DB_ADMIN_PASSWORD')
+            if not app.config.get(var)
+        ]
+        if missing_db_vars:
+            raise RuntimeError(f"Missing required database environment variables: {', '.join(missing_db_vars)}")
+
         Config.init_app(app)
         logger.info("Production configuration loaded")
 


### PR DESCRIPTION
Hi there! 👋

While going through the codebase, I noticed a minor opportunity for improvement regarding `backend/config.py`.

**Context:**
The config includes usable default credentials (`DB_USER='warranty_user'`, `DB_PASSWORD='warranty_password'`, `DB_ADMIN_USER='warracker_admin'`, `DB_ADMIN_PASSWORD='change_this_password_in_production'`). In real deployments, missing env vars will silently activate these predictable credentials, allowing unauthorized DB access if the database is reachable.


**Proposed fix:**
Remove credential defaults and require environment variables at startup. Example: `DB_PASSWORD = os.environ["DB_PASSWORD"]` (same for admin creds), and raise a clear startup error if unset. If local development needs defaults, isolate them in a dedicated non-production config class not used in Docker/CI/prod.

**Files touched:**
- `backend/config.py` (modified)

*(Note: Tested the changes locally to ensure everything works as expected. Let me know if you need any adjustments, happy to help!)*

—
**NamNV**
📍 Hanoi, Vietnam
📧 nam.nv205106@gmail.com
