### PR TITLE
Add mobile photo capture with client-side image downscaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## Unreleased
+
+### Added
+- **Mobile Photo Capture and Client-Side Image Downscaling:** Added a "Take Photo" button that opens the camera directly on mobile (the photo never enters the phone's gallery) and automatic client-side downscaling of product photos to max 2048px JPEG before upload.
+  - Downscaling is EXIF-orientation-safe, renders transparency on white, never produces a larger file, and falls back to the original file on any error
+  - Applies to the add and edit warranty photo inputs on both the main and status pages
+  - _Files: `frontend/index.html`, `frontend/status.html`, `frontend/script.js`, `frontend/sw.js`, `locales/*/translation.json`_
+
 ## 1.0.3 - 2026-05-18
 
 ### Fixed

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -537,6 +537,10 @@
                                             </label>
                                             <input type="file" id="productPhoto" name="product_photo" class="file-input" accept=".png,.jpg,.jpeg,.webp">
                                         </div>
+                                        <label for="productPhotoCamera" class="file-input-label">
+                                            <i class="fas fa-camera"></i> <span data-i18n="warranties.take_photo">Take Photo</span>
+                                        </label>
+                                        <input type="file" accept="image/*" capture="environment" id="productPhotoCamera" style="display: none;">
                                         <div id="productPhotoFileName" class="file-name"></div>
                                         <div id="productPhotoPreview" class="photo-preview" style="display: none;">
                                             <img id="productPhotoImg" src="" alt="Product Photo Preview" style="max-width: 200px; max-height: 200px; border-radius: 8px; margin-top: 10px;">
@@ -941,6 +945,10 @@
                                 </label>
                                 <input type="file" id="editProductPhoto" name="product_photo" class="file-input" accept=".png,.jpg,.jpeg,.webp">
                             </div>
+                            <label for="editProductPhotoCamera" class="file-input-label">
+                                <i class="fas fa-camera"></i> <span data-i18n="warranties.take_photo">Take Photo</span>
+                            </label>
+                            <input type="file" accept="image/*" capture="environment" id="editProductPhotoCamera" style="display: none;">
                             <div id="editProductPhotoFileName" class="file-name"></div>
                             <div id="editProductPhotoPreview" class="photo-preview" style="display: none;">
                                 <img id="editProductPhotoImg" src="" alt="Product Photo Preview" style="max-width: 200px; max-height: 200px; border-radius: 8px; margin-top: 10px;">
@@ -1327,7 +1335,7 @@
     
     <script type="module" src="js/index.js?v=20260518004"></script>
     <script src="auth.js?v=20250119001"></script>
-    <script src="script.js?v=20260518002"></script>
+    <script src="script.js?v=20260718001"></script>
     <script>
         // Lightweight UI logic for Filter/Sort popovers (no change to core logic)
         document.addEventListener('DOMContentLoaded', function () {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1335,7 +1335,7 @@
     
     <script type="module" src="js/index.js?v=20260518004"></script>
     <script src="auth.js?v=20250119001"></script>
-    <script src="script.js?v=20260718001"></script>
+    <script src="script.js?v=20260719001"></script>
     <script>
         // Lightweight UI logic for Filter/Sort popovers (no change to core logic)
         document.addEventListener('DOMContentLoaded', function () {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -533,11 +533,11 @@
                                         <label data-i18n="warranties.product_photo_optional">Product Photo (Optional)</label>
                                         <div class="file-input-wrapper">
                                             <label for="productPhoto" class="file-input-label">
-                                                <i class="fas fa-camera"></i> <span data-i18n="warranties.choose_photo">Choose Photo</span>
+                                                <i class="fas fa-upload"></i> <span data-i18n="warranties.choose_photo">Choose Photo</span>
                                             </label>
                                             <input type="file" id="productPhoto" name="product_photo" class="file-input" accept=".png,.jpg,.jpeg,.webp">
                                         </div>
-                                        <label for="productPhotoCamera" class="file-input-label">
+                                        <label for="productPhotoCamera" class="file-input-label" tabindex="0">
                                             <i class="fas fa-camera"></i> <span data-i18n="warranties.take_photo">Take Photo</span>
                                         </label>
                                         <input type="file" accept="image/*" capture="environment" id="productPhotoCamera" style="display: none;">
@@ -941,11 +941,11 @@
                             <label data-i18n="warranties.product_photo_optional">Product Photo (Optional)</label>
                             <div class="file-input-wrapper">
                                 <label for="editProductPhoto" class="file-input-label">
-                                    <i class="fas fa-camera"></i> <span data-i18n="warranties.choose_photo">Choose Photo</span>
+                                    <i class="fas fa-upload"></i> <span data-i18n="warranties.choose_photo">Choose Photo</span>
                                 </label>
                                 <input type="file" id="editProductPhoto" name="product_photo" class="file-input" accept=".png,.jpg,.jpeg,.webp">
                             </div>
-                            <label for="editProductPhotoCamera" class="file-input-label">
+                            <label for="editProductPhotoCamera" class="file-input-label" tabindex="0">
                                 <i class="fas fa-camera"></i> <span data-i18n="warranties.take_photo">Take Photo</span>
                             </label>
                             <input type="file" accept="image/*" capture="environment" id="editProductPhotoCamera" style="display: none;">
@@ -1335,7 +1335,7 @@
     
     <script type="module" src="js/index.js?v=20260518004"></script>
     <script src="auth.js?v=20250119001"></script>
-    <script src="script.js?v=20260719001"></script>
+    <script src="script.js?v=20260719002"></script>
     <script>
         // Lightweight UI logic for Filter/Sort popovers (no change to core logic)
         document.addEventListener('DOMContentLoaded', function () {

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -3471,7 +3471,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (warrantyForm) {
         initWarrantyForm();
     }
-    // Photo capture/downscale for pages that have the inputs but not the add form (e.g. status)
+    // Sole registration point for photo capture/downscale — presence-keyed, covers every page
     setupPhotoCapture('productPhoto');
     setupPhotoCapture('editProductPhoto');
     

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1206,16 +1206,19 @@ function updateFileName(event, inputId = 'invoice', outputId = 'fileName') {
     }
 }
 
-// Downscale large images client-side before upload (progressive enhancement)
-const downscaledFiles = new WeakSet();
-
+// Downscale large images client-side before upload (progressive enhancement).
+// Also re-encodes large (>= 1MB) non-JPEG images to JPEG, flattening transparency
+// onto white; animated GIFs pass through untouched to preserve animation.
 async function downscaleImage(file, maxEdge = 2048, quality = 0.85) {
     try {
-        if (!file || (file.type && !file.type.startsWith('image/')) || typeof createImageBitmap === 'undefined') {
+        if (!file || file.type === 'image/gif' ||
+            (file.type && !file.type.startsWith('image/')) ||
+            typeof createImageBitmap === 'undefined') {
             return file;
         }
 
         const bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' });
+        let canvas = null;
         try {
             if (bitmap.width <= maxEdge && bitmap.height <= maxEdge && (file.type === 'image/jpeg' || file.size < 1024 * 1024)) {
                 return file;
@@ -1226,13 +1229,14 @@ async function downscaleImage(file, maxEdge = 2048, quality = 0.85) {
             const width = Math.round(bitmap.width * scale);
             const height = Math.round(bitmap.height * scale);
 
-            const canvas = document.createElement('canvas');
+            canvas = document.createElement('canvas');
             canvas.width = width;
             canvas.height = height;
             const ctx = canvas.getContext('2d');
             ctx.fillStyle = '#ffffff';
             ctx.fillRect(0, 0, canvas.width, canvas.height);
             ctx.drawImage(bitmap, 0, 0, width, height);
+            bitmap.close();   // free the full-res bitmap before the encode; close() is idempotent
 
             const blob = await new Promise((resolve, reject) => {
                 canvas.toBlob(function(result) {
@@ -1252,6 +1256,7 @@ async function downscaleImage(file, maxEdge = 2048, quality = 0.85) {
             return new File([blob], jpgName, { type: 'image/jpeg' });
         } finally {
             bitmap.close();
+            if (canvas) canvas.width = canvas.height = 0;   // release the backing store deterministically
         }
     } catch (err) {
         console.warn('[DEBUG] Image downscale failed, using original file:', err);
@@ -1263,56 +1268,73 @@ function setupPhotoCapture(namedInputId) {
     const namedInput = document.getElementById(namedInputId);
     if (!namedInput) return;
 
+    // Files this handler already produced or inspected; membership means
+    // "do not process again" and breaks the synthetic-change loop below.
+    const handledFiles = new WeakSet();
+
+    function trySetFiles(input, file) {
+        // Copy through a fresh DataTransfer: assigning another input's FileList directly
+        // would share one list object, and clearing the source input would empty it too.
+        try {
+            const dt = new DataTransfer();
+            dt.items.add(file);
+            input.files = dt.files;
+            return true;
+        } catch (e) {
+            console.warn('[DEBUG] Could not set files on #' + input.id + ':', e);
+            return false;
+        }
+    }
+
     const cameraInput = document.getElementById(namedInputId + 'Camera');
-    if (cameraInput) {
+    const cameraLabel = cameraInput ? document.querySelector('label[for="' + cameraInput.id + '"]') : null;
+    if (cameraInput && typeof DataTransfer === 'undefined' && cameraLabel) {
+        // Without DataTransfer the capture pipeline cannot deliver a file — hide the
+        // button instead of failing silently after the user has taken a photo.
+        cameraLabel.style.display = 'none';
+    } else if (cameraInput) {
+        if (cameraLabel) {
+            cameraLabel.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    cameraInput.click();
+                }
+            });
+        }
         cameraInput.addEventListener('change', () => {
-            const file = cameraInput.files && cameraInput.files[0];
+            let file = cameraInput.files && cameraInput.files[0];
+            cameraInput.value = '';
             if (!file) return;
             // Reject known non-image types only; some Android pickers report an empty
             // MIME type for valid camera JPEGs (capture is a hint; desktop pickers allow any file).
-            if (file.type && !file.type.startsWith('image/')) {
-                cameraInput.value = '';
-                return;
+            if (file.type && !file.type.startsWith('image/')) return;
+            if (!file.type) {
+                // Normalize so preview code (gated on image/*) works; camera captures are JPEG.
+                file = new File([file], file.name, { type: 'image/jpeg' });
             }
             // Synchronous copy: the named input is populated immediately, so a fast
-            // Save never races an async gap; downscaling happens via the change listener below.
-            // Copy through a fresh DataTransfer — assigning cameraInput.files directly would
-            // share one FileList, and clearing the camera input below would empty it too.
-            try {
-                const dt = new DataTransfer();
-                dt.items.add(file);
-                namedInput.files = dt.files;
-            } catch (e) {
-                console.warn('[DEBUG] Camera file copy failed:', e);
-                cameraInput.value = '';
-                return;
-            }
-            cameraInput.value = '';
+            // Save never races the async downscale in the change listener below.
+            if (!trySetFiles(namedInput, file)) return;
+            // Note: change listeners on this input fire again after the downscale
+            // swap, with a different File — listeners must be idempotent.
             namedInput.dispatchEvent(new Event('change', { bubbles: true }));
         });
     }
 
     // Downscale-on-change for this input — independent of camera markup presence.
-    let generation = 0;
     namedInput.addEventListener('change', async () => {
         const file = namedInput.files && namedInput.files[0];
-        if (!file || downscaledFiles.has(file)) return;
-        // Empty MIME types still get a downscale attempt: createImageBitmap sniffs content,
-        // and a non-image simply fails decode and falls back to the original.
-        if (file.type && !file.type.startsWith('image/')) return;
-        const gen = ++generation;
+        if (!file || handledFiles.has(file)) return;
         const processed = await downscaleImage(file);
-        if (processed === file) return;              // nothing to improve
-        if (gen !== generation) return;              // a newer selection superseded this run
-        if (namedInput.files[0] !== file) return;    // input was cleared/replaced (form reset, modal close)
-        try {
-            const dt = new DataTransfer();
-            dt.items.add(processed);
-            downscaledFiles.add(processed);
-            namedInput.files = dt.files;
-            namedInput.dispatchEvent(new Event('change', { bubbles: true }));  // refresh label/preview with the processed file
-        } catch (e) {
-            console.warn('[DEBUG] Downscale swap failed, uploading original:', e);
+        if (processed === file) {
+            handledFiles.add(file);                  // nothing to improve; skip re-inspection on re-fired events
+            return;
+        }
+        if (namedInput.files[0] !== file) return;    // input was cleared/replaced meanwhile (new pick, form reset)
+        handledFiles.add(processed);
+        if (trySetFiles(namedInput, processed)) {
+            // Second change with the swapped (downscaled) File — see note above.
+            namedInput.dispatchEvent(new Event('change', { bubbles: true }));
         }
     });
 }

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1206,6 +1206,113 @@ function updateFileName(event, inputId = 'invoice', outputId = 'fileName') {
     }
 }
 
+// Downscale large images client-side before upload (progressive enhancement)
+const downscaledFiles = new WeakSet();
+
+async function downscaleImage(file, maxEdge = 2048, quality = 0.85) {
+    try {
+        if (!file || (file.type && !file.type.startsWith('image/')) || typeof createImageBitmap === 'undefined') {
+            return file;
+        }
+
+        const bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' });
+        try {
+            if (bitmap.width <= maxEdge && bitmap.height <= maxEdge && (file.type === 'image/jpeg' || file.size < 1024 * 1024)) {
+                return file;
+            }
+
+            const longest = Math.max(bitmap.width, bitmap.height);
+            const scale = Math.min(1, maxEdge / longest);
+            const width = Math.round(bitmap.width * scale);
+            const height = Math.round(bitmap.height * scale);
+
+            const canvas = document.createElement('canvas');
+            canvas.width = width;
+            canvas.height = height;
+            const ctx = canvas.getContext('2d');
+            ctx.fillStyle = '#ffffff';
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+            ctx.drawImage(bitmap, 0, 0, width, height);
+
+            const blob = await new Promise((resolve, reject) => {
+                canvas.toBlob(function(result) {
+                    if (result) {
+                        resolve(result);
+                    } else {
+                        reject(new Error('canvas.toBlob returned null'));
+                    }
+                }, 'image/jpeg', quality);
+            });
+
+            if (blob.size >= file.size) {
+                return file;
+            }
+
+            const jpgName = file.name.replace(/\.[^.]+$/, '') + '.jpg';
+            return new File([blob], jpgName, { type: 'image/jpeg' });
+        } finally {
+            bitmap.close();
+        }
+    } catch (err) {
+        console.warn('[DEBUG] Image downscale failed, using original file:', err);
+        return file;
+    }
+}
+
+function setupPhotoCapture(namedInputId) {
+    const namedInput = document.getElementById(namedInputId);
+    if (!namedInput) return;
+
+    const cameraInput = document.getElementById(namedInputId + 'Camera');
+    if (cameraInput) {
+        cameraInput.addEventListener('change', () => {
+            const file = cameraInput.files && cameraInput.files[0];
+            if (!file) return;
+            // Reject known non-image types only; some Android pickers report an empty
+            // MIME type for valid camera JPEGs (capture is a hint; desktop pickers allow any file).
+            if (file.type && !file.type.startsWith('image/')) {
+                cameraInput.value = '';
+                return;
+            }
+            // Synchronous copy: the named input is populated immediately, so a fast
+            // Save never races an async gap; downscaling happens via the change listener below.
+            try {
+                namedInput.files = cameraInput.files;
+            } catch (e) {
+                console.warn('[DEBUG] Camera file copy failed:', e);
+                cameraInput.value = '';
+                return;
+            }
+            cameraInput.value = '';
+            namedInput.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+    }
+
+    // Downscale-on-change for this input — independent of camera markup presence.
+    let generation = 0;
+    namedInput.addEventListener('change', async () => {
+        const file = namedInput.files && namedInput.files[0];
+        if (!file || downscaledFiles.has(file)) return;
+        // Empty MIME types still get a downscale attempt: createImageBitmap sniffs content,
+        // and a non-image simply fails decode and falls back to the original.
+        if (file.type && !file.type.startsWith('image/')) return;
+        const gen = ++generation;
+        const processed = await downscaleImage(file);
+        if (processed === file) return;              // nothing to improve
+        if (gen !== generation) return;              // a newer selection superseded this run
+        if (namedInput.files[0] !== file) return;    // input was cleared/replaced (form reset, modal close)
+        try {
+            const dt = new DataTransfer();
+            dt.items.add(processed);
+            downscaledFiles.add(processed);
+            namedInput.files = dt.files;
+            namedInput.dispatchEvent(new Event('change', { bubbles: true }));  // refresh label/preview with the processed file
+        } catch (e) {
+            console.warn('[DEBUG] Downscale swap failed, uploading original:', e);
+        }
+    });
+}
+
 // Helper function to process warranty data
 function processWarrantyData(warranty) {
     console.log('Processing warranty data:', warranty);
@@ -3338,6 +3445,9 @@ document.addEventListener('DOMContentLoaded', function() {
     if (warrantyForm) {
         initWarrantyForm();
     }
+    // Photo capture/downscale for pages that have the inputs but not the add form (e.g. status)
+    setupPhotoCapture('productPhoto');
+    setupPhotoCapture('editProductPhoto');
     
     // Load warranties (might need checks if warrantiesList doesn't always exist)
     if (warrantiesList) { 

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1276,8 +1276,12 @@ function setupPhotoCapture(namedInputId) {
             }
             // Synchronous copy: the named input is populated immediately, so a fast
             // Save never races an async gap; downscaling happens via the change listener below.
+            // Copy through a fresh DataTransfer — assigning cameraInput.files directly would
+            // share one FileList, and clearing the camera input below would empty it too.
             try {
-                namedInput.files = cameraInput.files;
+                const dt = new DataTransfer();
+                dt.items.add(file);
+                namedInput.files = dt.files;
             } catch (e) {
                 console.warn('[DEBUG] Camera file copy failed:', e);
                 cameraInput.value = '';

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -37,7 +37,7 @@
     <script src="js/i18n.js?v=20250119001"></script>
     <!-- Load fix for auth buttons -->
     <script src="fix-auth-buttons-loader.js?v=20250119001"></script>
-    <script src="script.js?v=20260518002" defer></script> <!-- Added script.js -->
+    <script src="script.js?v=20260718001" defer></script> <!-- Added script.js -->
     <script src="status.js?v=20250119001" defer></script> <!-- Status page specific functionality -->
     <style>
         .user-menu {
@@ -670,6 +670,10 @@
                                 </label>
                                 <input type="file" id="editProductPhoto" name="product_photo" class="file-input" accept=".png,.jpg,.jpeg,.webp">
                             </div>
+                            <label for="editProductPhotoCamera" class="file-input-label">
+                                <i class="fas fa-camera"></i> <span data-i18n="warranties.take_photo">Take Photo</span>
+                            </label>
+                            <input type="file" accept="image/*" capture="environment" id="editProductPhotoCamera" style="display: none;">
                             <div id="editProductPhotoFileName" class="file-name"></div>
                             <div id="editProductPhotoPreview" class="photo-preview" style="display: none;">
                                 <img id="editProductPhotoImg" src="" alt="Product Photo Preview" style="max-width: 200px; max-height: 200px; border-radius: 8px; margin-top: 10px;">

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -37,7 +37,7 @@
     <script src="js/i18n.js?v=20250119001"></script>
     <!-- Load fix for auth buttons -->
     <script src="fix-auth-buttons-loader.js?v=20250119001"></script>
-    <script src="script.js?v=20260718001" defer></script> <!-- Added script.js -->
+    <script src="script.js?v=20260719001" defer></script> <!-- Added script.js -->
     <script src="status.js?v=20250119001" defer></script> <!-- Status page specific functionality -->
     <style>
         .user-menu {

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -37,7 +37,7 @@
     <script src="js/i18n.js?v=20250119001"></script>
     <!-- Load fix for auth buttons -->
     <script src="fix-auth-buttons-loader.js?v=20250119001"></script>
-    <script src="script.js?v=20260719001" defer></script> <!-- Added script.js -->
+    <script src="script.js?v=20260719002" defer></script> <!-- Added script.js -->
     <script src="status.js?v=20250119001" defer></script> <!-- Status page specific functionality -->
     <style>
         .user-menu {
@@ -670,7 +670,7 @@
                                 </label>
                                 <input type="file" id="editProductPhoto" name="product_photo" class="file-input" accept=".png,.jpg,.jpeg,.webp">
                             </div>
-                            <label for="editProductPhotoCamera" class="file-input-label">
+                            <label for="editProductPhotoCamera" class="file-input-label" tabindex="0">
                                 <i class="fas fa-camera"></i> <span data-i18n="warranties.take_photo">Take Photo</span>
                             </label>
                             <input type="file" accept="image/*" capture="environment" id="editProductPhotoCamera" style="display: none;">

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'warracker-cache-v20260518005';
+const CACHE_NAME = 'warracker-cache-v20260718001';
 const urlsToCache = [
   // HTML pages
   './',
@@ -21,7 +21,7 @@ const urlsToCache = [
   './mobile-header.css?v=20250119002',
 
   // JavaScript (versioned)
-  './script.js?v=20260518002',
+  './script.js?v=20260718001',
   './auth.js?v=20250119001',
   './settings-new.js?v=20250119001',
   './status.js?v=20250119001',

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'warracker-cache-v20260719001';
+const CACHE_NAME = 'warracker-cache-v20260719002';
 const urlsToCache = [
   // HTML pages
   './',
@@ -21,7 +21,7 @@ const urlsToCache = [
   './mobile-header.css?v=20250119002',
 
   // JavaScript (versioned)
-  './script.js?v=20260719001',
+  './script.js?v=20260719002',
   './auth.js?v=20250119001',
   './settings-new.js?v=20250119001',
   './status.js?v=20250119001',

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'warracker-cache-v20260718001';
+const CACHE_NAME = 'warracker-cache-v20260719001';
 const urlsToCache = [
   // HTML pages
   './',
@@ -21,7 +21,7 @@ const urlsToCache = [
   './mobile-header.css?v=20250119002',
 
   // JavaScript (versioned)
-  './script.js?v=20260718001',
+  './script.js?v=20260719001',
   './auth.js?v=20250119001',
   './settings-new.js?v=20250119001',
   './status.js?v=20250119001',

--- a/locales/ar/translation.json
+++ b/locales/ar/translation.json
@@ -174,6 +174,7 @@
     "add_any_notes": "أضف أي ملاحظات حول هذا الضمان...",
     "product_photo_optional": "صورة المنتج (اختياري)",
     "choose_photo": "اختر صورة",
+    "take_photo": "التقاط صورة",
     "invoice_receipt": "فاتورة/إيصال",
     "store_locally": "حفظ محلياً",
     "store_in_paperless": "حفظ في Paperless-ngx",

--- a/locales/cs/translation.json
+++ b/locales/cs/translation.json
@@ -151,6 +151,7 @@
     "add_any_notes": "Přidejte jakékoli poznámky k této záruce...",
     "product_photo_optional": "Fotografie produktu (volitelné)",
     "choose_photo": "Vybrat fotografii",
+    "take_photo": "Vyfotit",
     "invoice_receipt": "Faktura/Účtenka",
     "store_locally": "Uložit lokálně",
     "store_in_paperless": "Uložit v Paperless-ngx",

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -144,6 +144,7 @@
     "add_any_notes": "Fügen Sie Notizen zu dieser Garantie hinzu...",
     "product_photo_optional": "Produktfoto (optional)",
     "choose_photo": "Foto auswählen",
+    "take_photo": "Foto aufnehmen",
     "invoice_receipt": "Rechnung/Beleg",
     "store_locally": "Lokal speichern",
     "store_in_paperless": "In Paperless-ngx speichern",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -142,6 +142,7 @@
     "add_any_notes": "Add any notes about this warranty...",
     "product_photo_optional": "Product Photo (Optional)",
     "choose_photo": "Choose Photo",
+    "take_photo": "Take Photo",
     "invoice_receipt": "Invoice",
     "store_locally": "Store Locally",
     "store_in_paperless": "Store in Paperless-ngx",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -142,6 +142,7 @@
     "add_any_notes": "Añada cualquier nota sobre esta garantía...",
     "product_photo_optional": "Foto del producto (opcional)",
     "choose_photo": "Elegir foto",
+    "take_photo": "Tomar foto",
     "invoice_receipt": "Factura/Recibo",
     "store_locally": "Almacenar localmente",
     "store_in_paperless": "Almacenar en Paperless-ngx",

--- a/locales/fa/translation.json
+++ b/locales/fa/translation.json
@@ -145,6 +145,7 @@
     "add_any_notes": "هرگونه یادداشتی در مورد این گارانتی اضافه کنید...",
     "product_photo_optional": "عکس محصول (اختیاری)",
     "choose_photo": "انتخاب عکس",
+    "take_photo": "گرفتن عکس",
     "invoice_receipt": "فاکتور/رسید",
     "store_locally": "ذخیره محلی",
     "store_in_paperless": "ذخیره در Paperless-ngx",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -146,6 +146,7 @@
     "add_any_notes": "Ajoutez des notes sur cette garantie...",
     "product_photo_optional": "Photo du produit (facultatif)",
     "choose_photo": "Choisir une photo",
+    "take_photo": "Prendre une photo",
     "invoice_receipt": "Facture/Reçu",
     "store_locally": "Stocker localement",
     "store_in_paperless": "Stocker dans Paperless-ngx",

--- a/locales/he/translation.json
+++ b/locales/he/translation.json
@@ -177,6 +177,7 @@
     "add_any_notes": "הוסף הערות לגבי אחריות זו...",
     "product_photo_optional": "תמונת מוצר (אופציונלי)",
     "choose_photo": "בחר תמונה",
+    "take_photo": "צלם תמונה",
     "invoice_receipt": "חשבונית/קבלה",
     "store_locally": "שמור מקומית",
     "store_in_paperless": "שמור ב-Paperless-ngx",

--- a/locales/hi/translation.json
+++ b/locales/hi/translation.json
@@ -144,6 +144,7 @@
     "add_any_notes": "इस वारंटी के बारे में कोई नोट्स जोड़ें...",
     "product_photo_optional": "उत्पाद फोटो (वैकल्पिक)",
     "choose_photo": "फोटो चुनें",
+    "take_photo": "फ़ोटो लें",
     "invoice_receipt": "चालान/रसीद",
     "store_locally": "स्थानीय रूप से स्टोर करें",
     "store_in_paperless": "Paperless-ngx में स्टोर करें",

--- a/locales/it/translation.json
+++ b/locales/it/translation.json
@@ -363,6 +363,7 @@
     "add_any_notes": "Aggiungi note su questa garanzia...",
     "product_photo_optional": "Foto Prodotto (Opzionale)",
     "choose_photo": "Scegli Foto",
+    "take_photo": "Scatta foto",
     "invoice_receipt": "Fattura/Ricevuta",
     "store_locally": "Memorizza Localmente",
     "store_in_paperless": "Memorizza in Paperless-ngx",

--- a/locales/ja/translation.json
+++ b/locales/ja/translation.json
@@ -145,6 +145,7 @@
     "add_any_notes": "この保証に関するメモを追加...",
     "product_photo_optional": "製品写真（オプション）",
     "choose_photo": "写真を選択",
+    "take_photo": "写真を撮る",
     "invoice_receipt": "請求書/領収書",
     "store_locally": "ローカルに保存",
     "store_in_paperless": "Paperless-ngxに保存",

--- a/locales/ko/translation.json
+++ b/locales/ko/translation.json
@@ -145,6 +145,7 @@
     "add_any_notes": "이 보증에 대한 메모 추가...",
     "product_photo_optional": "제품 사진 (선택 사항)",
     "choose_photo": "사진 선택",
+    "take_photo": "사진 촬영",
     "invoice_receipt": "송장/영수증",
     "store_locally": "로컬에 저장",
     "store_in_paperless": "Paperless-ngx에 저장",

--- a/locales/nl/translation.json
+++ b/locales/nl/translation.json
@@ -144,6 +144,7 @@
     "add_any_notes": "Voeg notities over deze garantie toe...",
     "product_photo_optional": "Productfoto (optioneel)",
     "choose_photo": "Kies foto",
+    "take_photo": "Foto maken",
     "invoice_receipt": "Factuur/Bon",
     "store_locally": "Lokaal opslaan",
     "store_in_paperless": "Opslaan in Paperless-ngx",

--- a/locales/pl/translation.json
+++ b/locales/pl/translation.json
@@ -141,6 +141,7 @@
     "add_any_notes": "Dodaj notatki dotyczące tej gwarancji...",
     "product_photo_optional": "Zdjęcie produktu (opcjonalnie)",
     "choose_photo": "Wybierz zdjęcie",
+    "take_photo": "Zrób zdjęcie",
     "invoice_receipt": "Faktura/Paragon",
     "store_locally": "Przechowuj lokalnie",
     "store_in_paperless": "Przechowuj w Paperless-ngx",

--- a/locales/pt/translation.json
+++ b/locales/pt/translation.json
@@ -145,6 +145,7 @@
     "add_any_notes": "Adicione qualquer nota sobre esta garantia...",
     "product_photo_optional": "Foto do Produto (Opcional)",
     "choose_photo": "Escolher Foto",
+    "take_photo": "Tirar foto",
     "invoice_receipt": "Fatura/Recibo",
     "store_locally": "Armazenar Localmente",
     "store_in_paperless": "Armazenar no Paperless-ngx",

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -151,6 +151,7 @@
     "add_any_notes": "Добавьте любые заметки об этой гарантии...",
     "product_photo_optional": "Фото продукта (необязательно)",
     "choose_photo": "Выберите фото",
+    "take_photo": "Сделать фото",
     "invoice_receipt": "Счет/Чек",
     "store_locally": "Хранить локально",
     "store_in_paperless": "Хранить в Paperless-ngx",

--- a/locales/tr/translation.json
+++ b/locales/tr/translation.json
@@ -492,6 +492,7 @@
     "add_any_notes": "Bu garanti hakkında herhangi bir not ekleyin...",
     "product_photo_optional": "Ürün Fotoğrafı (İsteğe Bağlı)",
     "choose_photo": "Fotoğraf Seç",
+    "take_photo": "Fotoğraf çek",
     "invoice_receipt": "Fatura/Fiş",
     "store_locally": "Yerel Olarak Sakla",
     "store_in_paperless": "Paperless-ngx'te Sakla",

--- a/locales/uk/translation.json
+++ b/locales/uk/translation.json
@@ -151,6 +151,7 @@
     "add_any_notes": "Додайте будь-які нотатки про цю гарантію...",
     "product_photo_optional": "Фото продукту (необов'язково)",
     "choose_photo": "Виберіть фото",
+    "take_photo": "Зробити фото",
     "invoice_receipt": "Рахунок/Чек",
     "store_locally": "Зберігати локально",
     "store_in_paperless": "Зберігати в Paperless-ngx",

--- a/locales/zh_CN/translation.json
+++ b/locales/zh_CN/translation.json
@@ -146,6 +146,7 @@
     "add_any_notes": "填写这条保修记录的备注...",
     "product_photo_optional": "产品照片（可选）",
     "choose_photo": "选择照片",
+    "take_photo": "拍照",
     "invoice_receipt": "发票/收据",
     "store_locally": "本地存储",
     "store_in_paperless": "存到 Paperless-ngx",

--- a/locales/zh_HK/translation.json
+++ b/locales/zh_HK/translation.json
@@ -145,6 +145,7 @@
     "add_any_notes": "新增關於此保養的任何備註...",
     "product_photo_optional": "產品照片（可選）",
     "choose_photo": "選擇照片",
+    "take_photo": "拍照",
     "invoice_receipt": "發票/收據",
     "store_locally": "本地儲存",
     "store_in_paperless": "儲存在Paperless-ngx",


### PR DESCRIPTION
I run Warracker on my home server and it replaced my own warranty tracker app, but the one thing that kept bugging me was adding receipts from the phone. Right after a purchase you want to snap the receipt and be done, instead the flow was: open camera app, take photo, remember to resize it (phone photos are 8-15MB, easy to hit MAX_UPLOAD_MB), upload through the file picker, then go delete the receipt from the gallery. This PR fixes that whole path.

What it does:

- adds a "Take Photo" button next to Choose Photo (add form + both edit modals, index and status). It's a hidden `<input accept="image/*" capture="environment">`, so on mobile the camera opens directly and the photo never lands in the gallery
- client-side downscaling of product photos before upload: max 2048px on the longest edge, JPEG q0.85. EXIF orientation is handled, transparency gets flattened on white, animated GIFs pass through untouched, and if the result would be larger than the original the original wins. Any decode error just falls back to the original file, downscaling never blocks an upload
- applies to gallery picks too, not only camera capture, so large desktop uploads shrink as well

Implementation notes:

- everything hooks into the change event and swaps the file back into the named input via DataTransfer, so both submit paths (add form FormData, edit save reading files[0]) pick it up without touching any submit code. The swap re-fires change with the new File, there's a comment at both dispatch sites since listeners see two events per selection
- the button is capability gated, if the browser has no DataTransfer constructor it's hidden instead of failing after the user took a photo. Labels are keyboard operable
- `warranties.take_photo` added to all 20 locale files
- cache busting follows the repo convention (?v= bump in both html files + sw.js precache + CACHE_NAME)

Testing: this exact branch (well, the same commits on a 1.0.2 base) has been running on my own instance for a few days with real phone use, and I have a Playwright harness that drives both the add and edit flow headless against a docker compose stack, asserting the photo actually lands in the DB downscaled. Happy to share the harness script if you want it in the repo.

Known limitation: if someone picks a file the browser can't decode (e.g. HEIC on a non-Safari desktop) it passes through unconverted and the backend rejects the extension, same as today. In practice camera captures are always JPEG so this doesn't bite on the main path.

Your contributing notes say to discuss in an issue first, sorry for jumping straight to code, this started as a patch for my own instance and grew into something shareable. Happy to split or rework whatever doesn't fit, e.g. if you'd rather have this in the frontend/js component layer I can move it there.
