### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,10 +323,10 @@ This project is licensed under the GNU Affero General Public License v3.0 - see 
 
 
 ## ⭐Star History
-<a href="https://star-history.com/#sassanix/Warracker&Date">
+<a href="https://star-history.dera.page/#sassanix/Warracker&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=sassanix/Warracker&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=sassanix/Warracker&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=sassanix/Warracker&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=sassanix/Warracker&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=sassanix/Warracker&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=sassanix/Warracker&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer renders, so visitors can no longer see the project's growth over time. This change updates the chart image and its link to a working star history service so the chart is displayed correctly again.